### PR TITLE
Remove ansible dependency on host

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,7 +8,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     monitoring.vm.box = "ubuntu/xenial64"
     monitoring.vm.network :private_network, ip: "172.0.0.10"
 
-    monitoring.vm.provision "ansible" do |ansible| 
+    monitoring.vm.provision "ansible_local" do |ansible| 
       ansible.playbook = "monitoring.yml"
       # ansible.raw_arguments = ["-vvv"]
     end 


### PR DESCRIPTION
As per the [docs](https://www.vagrantup.com/docs/provisioning/ansible_local.html), we can use `ansible_local` instead of `ansible` as the provisioner - Vagrant installs and uses ansible on the guest to setup the guest itself.
This removes the need for host ansible support (for example, windows, where ansible is not supported).